### PR TITLE
Error handling

### DIFF
--- a/lib/spacesuit/api_message.ex
+++ b/lib/spacesuit/api_message.ex
@@ -5,7 +5,7 @@
 # Just does JSON for now
 defmodule Spacesuit.ApiMessage do
   @derive [Poison.Encoder]
-  defstruct [:status, :message]
+  defstruct [:errorCode, :errorMessage]
 
   def encode(api_message) do
     Poison.encode!(api_message)

--- a/lib/spacesuit/auth_middleware.ex
+++ b/lib/spacesuit/auth_middleware.ex
@@ -11,7 +11,7 @@ defmodule Spacesuit.AuthMiddleware do
 
       "magic!" ->
         Logger.warn "Unauthorized request"
-        reply(req, 401, "Unauthorized")
+        reply(req, 401, "UNAUTHORIZED")
         {:halt, req}
 
       "Bearer " <> token ->
@@ -28,9 +28,9 @@ defmodule Spacesuit.AuthMiddleware do
     %{ req | headers: Map.delete(req[:headers], "authorization") }
   end
 
-  defp reply(req, code, message) do
+  defp reply(req, code, error) do
     msg = Spacesuit.ApiMessage.encode(
-      %Spacesuit.ApiMessage{status: "error", message: message}
+      %Spacesuit.ApiMessage{errorCode: error}
     )
     :cowboy_req.reply(code, %{}, msg, req)
   end
@@ -43,7 +43,7 @@ defmodule Spacesuit.AuthMiddleware do
       # TODO call session service
       {:ok, strip_auth(req), env}
     else
-      reply(req, 401, "Bad Authentication Token")
+      reply(req, 401, "INVALID_TOKEN")
       {:halt, req}
     end
   end

--- a/lib/spacesuit/auth_middleware.ex
+++ b/lib/spacesuit/auth_middleware.ex
@@ -52,6 +52,8 @@ defmodule Spacesuit.AuthMiddleware do
     result =
         token
         |> Joken.token
+        # is it possible to verify against alternatives here?
+        # that would make our lives easier if we want to rotate the secret / switch the algorithm
         |> Joken.with_signer(Joken.hs384(@jwt_secret))
         |> Joken.verify
 

--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -29,16 +29,17 @@ defmodule Spacesuit.ProxyHandler do
         stream(upstream, downstream)
 
       {:error, :econnrefused} ->
-        error_reply(req, 503, "Service Unavailable - Connection refused")
+        error_reply(req, 503, "SERVICE_UNAVAILABLE", "Connection refused")
 
       {:error, :closed} ->
-        error_reply(req, 502, "Bad Gateway - Connection closed")
+        error_reply(req, 502, "BAD_GATEWAY", "Connection closed")
 
       {:error, :timeout} ->
-        error_reply(req, 502, "Bad Gateway - Connection timeout")
+        error_reply(req, 502, "BAD_GATEWAY", "Connection timeout")
 
       {:error, :bad_request} ->
-        error_reply(req, 400, "Bad Request")
+        # What is this doing, the response for any bad request should be streamed through
+        error_reply(req, 400, "Bad Request", :nil)
 
       unexpected ->
         Logger.warn "Received unexpected upstream response: '#{inspect(unexpected)}'"
@@ -115,9 +116,9 @@ defmodule Spacesuit.ProxyHandler do
 
   # Send messages back to Cowboy, encoded in the format used
   # by the API
-  def error_reply(req, code, message) do
+  def error_reply(req, code, error, message) do
     msg = Spacesuit.ApiMessage.encode(
-      %Spacesuit.ApiMessage{status: "error", message: message}
+      %Spacesuit.ApiMessage{errorCode: error, errorMessage: message}
     )
     :cowboy_req.reply(code, %{}, msg, req)
   end

--- a/test/spacesuit_api_message_test.exs
+++ b/test/spacesuit_api_message_test.exs
@@ -3,13 +3,13 @@ defmodule SpacesuitApiMessageTest do
   doctest Spacesuit.ApiMessage
 
   test "encodes messages properly" do
-    msg = Spacesuit.ApiMessage.encode(%Spacesuit.ApiMessage{status: "error", message: "message"})
-    assert "{\"status\":" <> _ = msg
+    msg = Spacesuit.ApiMessage.encode(%Spacesuit.ApiMessage{errorCode: "error", errorMessage: "message"})
+    assert msg == "{\"errorMessage\":\"message\",\"errorCode\":\"error\"}"
   end
 
   test "decodes messages properly" do
-    msg = Spacesuit.ApiMessage.decode("{\"status\":\"error\",\"message\":\"message\"}")
-    assert msg.status == "error"
-    assert msg.message == "message"
+    msg = Spacesuit.ApiMessage.decode("{\"errorCode\":\"error\",\"errorMessage\":\"message\"}")
+    assert msg.errorCode == "error"
+    assert msg.errorMessage == "message"
   end
 end


### PR DESCRIPTION
@relistan just for discussion, not necessarily to be merged ...

Particularly for auth errors it would be good to stay compatible with the service response, for instance returns the service auth layer `{"errorCode":"INVALID_TOKEN"}` if token validation fails.

For the errors it's probably not to important to stick to that format.

Aside, a couple of notes / questions from reading through code