### PR TITLE
Support passing through the original url

### DIFF
--- a/lib/spacesuit/http_server.ex
+++ b/lib/spacesuit/http_server.ex
@@ -5,6 +5,7 @@ defmodule HttpServer do
   @callback has_body(Map.t) :: Boolean.t
   @callback read_body(Map.t) :: any
   @callback body_length(Map.t) :: Integer.t
+  @callback uri(Map.t) :: String.t
 end
 
 defmodule Spacesuit.HttpServer.Cowboy do
@@ -32,6 +33,10 @@ defmodule Spacesuit.HttpServer.Cowboy do
 
   def body_length(req) do
     :cowboy_req.body_length(req)
+  end
+
+  def uri(req) do
+    :cowboy_req.uri(req)
   end
 end
 
@@ -61,5 +66,9 @@ defmodule Spacesuit.HttpServer.Mock do
 
   def body_length(req) do
     String.length(req[:body] || "")
+  end
+
+  def uri(req) do
+    req[:url]
   end
 end

--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -16,7 +16,7 @@ defmodule Spacesuit.ProxyHandler do
     # Prepare some things we'll need
     ups_url     = build_upstream_url(req, state)
     peer        = format_peer(peer)
-    ups_headers = cowboy_to_hackney(headers, peer)
+    ups_headers = cowboy_to_hackney(headers, peer, @http_server.uri(req))
 
     # Make the proxy request
     req = handle_request(req, ups_url, ups_headers, method)
@@ -106,9 +106,10 @@ defmodule Spacesuit.ProxyHandler do
   end
 
   # Convery headers from Cowboy map format to Hackney list format
-  def cowboy_to_hackney(headers, peer) do
+  def cowboy_to_hackney(headers, peer, url) do
     (headers || %{})
       |> Map.put("X-Forwarded-For", peer)
+      |> Map.put("X-Forwarded-Url", url)
       |> Map.drop([ "host", "Host" ])
       |> Map.to_list
   end

--- a/test/spacesuit_proxy_handler_test.exs
+++ b/test/spacesuit_proxy_handler_test.exs
@@ -33,13 +33,17 @@ defmodule SpacesuitProxyHandlerTest do
     }
 
     peer = Spacesuit.ProxyHandler.format_peer({{127,0,0,1},32767})
-    processed = Spacesuit.ProxyHandler.cowboy_to_hackney(headers, peer)
+    original_url = "http://localhost:9090"
+    processed = Spacesuit.ProxyHandler.cowboy_to_hackney(headers, peer, original_url)
 
     assert {"X-Forwarded-For", "127.0.0.1"} =
       List.keyfind(processed, "X-Forwarded-For", 0)
 
     assert {"accept-language", "en-US,en;q=0.5"} =
       List.keyfind(processed, "accept-language", 0)
+
+    assert {"X-Forwarded-Url", ^original_url} =
+      List.keyfind(processed, "X-Forwarded-Url", 0)
 
     assert nil == List.keyfind(processed, "Host", 0)
   end


### PR DESCRIPTION
This will add an HTTP header to show the original proxied URL. This is required in environments where the original URL is signed in a token and needs to be validated by the upstream service. I was not able to find a standard header that does exactly this. I realize that `X-` headers are now discouraged/deprecated. However, this header makes the most sense to me given that we are already passing `X-Forwarded-For`.

@epileptic-fish @mosche @jopecko