### PR TITLE
Permit bypassing session service

### DIFF
--- a/lib/spacesuit/auth_middleware.ex
+++ b/lib/spacesuit/auth_middleware.ex
@@ -50,7 +50,10 @@ defmodule Spacesuit.AuthMiddleware do
 
   # should the session service be bypassed for this route?
   defp bypass_session_srv?(env) do
-    get_in(env, [:handler_opts, :middlewares_config, :auth, :bypass_session_srv]) || false
+    case get_in(env, [:handler_opts, :middleware, :session_service]) do
+      :disabled -> true
+      _         -> false
+    end
   end
 
   defp error_reply(req, code, message) do

--- a/lib/spacesuit/auth_middleware.ex
+++ b/lib/spacesuit/auth_middleware.ex
@@ -2,20 +2,20 @@ defmodule Spacesuit.AuthMiddleware do
   require Logger
   use Elixometer
 
+  @http_server     Application.get_env(:spacesuit, :http_server)
+
   @timed(key: "timed.authMiddleware-handle", units: :millisecond)
   def execute(req, env) do
-    session_service = Application.get_env(:spacesuit, :session_service)
-
     case req[:headers]["authorization"] do
       nil ->
         Logger.debug "No auth header"
         {:ok, req, env}
 
       "Bearer " <> token ->
-        case session_service[:enabled] do
+        case session_service()[:enabled] do
           true ->
-            session_service[:impl].handle_bearer_token(req, env, token, session_service[:url])
-          false -> 
+            handle_bearer_token(req, env, token)
+          false ->
             {:ok, req, env}
           _ ->
             Logger.warn "Session service :enabled not configured!"
@@ -29,7 +29,39 @@ defmodule Spacesuit.AuthMiddleware do
     end
   end
 
+  defp handle_bearer_token(req, env, token) do
+    if bypass_session_srv?(env) do
+      case session_service()[:impl].validate_api_token(token) do
+        :ok ->
+          {:ok, req, env}
+        unexpected -> # Otherwise we blow up the request
+          Logger.error "auth_middleware error: unexpected response - #{inspect(unexpected)}"
+          error_reply(req, 401, "Bad Authentication Token")
+          {:stop, req}
+      end
+    else
+      session_service()[:impl].handle_bearer_token(req, env, token, session_service()[:url])
+    end
+  end
+
   defp strip_auth(req) do
     %{ req | headers: Map.delete(req[:headers], "authorization") }
+  end
+
+  # should the session service be bypassed for this route?
+  defp bypass_session_srv?(env) do
+    get_in(env, [:handler_opts, :middlewares_config, :auth, :bypass_session_srv]) || false
+  end
+
+  defp error_reply(req, code, message) do
+    msg = Spacesuit.ApiMessage.encode(
+      %Spacesuit.ApiMessage{status: "error", message: message}
+    )
+    @http_server.reply(code, %{}, msg, req)
+  end
+
+  # Quick access function for the application settings for this middleware
+  def session_service do
+    Application.get_env(:spacesuit, :session_service)
   end
 end

--- a/test/spacesuit_auth_middleware_test.exs
+++ b/test/spacesuit_auth_middleware_test.exs
@@ -70,7 +70,7 @@ defmodule SpacesuitAuthMiddlewareTest do
 
     test "with a valid token on a bypassed path" do
       Application.put_env(:spacesuit, :session_service, %{ enabled: true, impl: Spacesuit.MockSessionService })
-      Application.put_env(:handler_opts, :middlewares_config, %{ auth: %{ bypass_session_srv: true } })
+      Application.put_env(:handler_opts, :middleware, %{ session_service: :disabled })
 
       req = %{ headers: %{ "authorization" => "Bearer ok" }, pid: self(), streamid: 1, method: "GET" }
       env = %{}
@@ -81,7 +81,7 @@ defmodule SpacesuitAuthMiddlewareTest do
 
     test "with an invalid token on a bypassed path" do
       Application.put_env(:spacesuit, :session_service, %{ enabled: true, impl: Spacesuit.MockSessionService })
-      Application.put_env(:handler_opts, :middlewares_config, %{ auth: %{ bypass_session_srv: true } })
+      Application.put_env(:handler_opts, :middleware, %{ session_service: :disabled })
 
       req = %{ headers: %{ "authorization" => "Bearer error" }, pid: self(), streamid: 1, method: "GET" }
       env = %{}

--- a/test/spacesuit_auth_middleware_test.exs
+++ b/test/spacesuit_auth_middleware_test.exs
@@ -48,7 +48,7 @@ defmodule SpacesuitAuthMiddlewareTest do
       assert {:stop, ^req} = Spacesuit.AuthMiddleware.execute(req, env)
     end
 
-   test "with a valid token when session service is enabled" do
+    test "with a valid token when session service is enabled" do
       Application.put_env(:spacesuit, :session_service, %{ enabled: true, impl: Spacesuit.MockSessionService })
 
       req = %{ headers: %{ "authorization" => "Bearer ok" }, pid: self(), streamid: 1, method: "GET" }
@@ -58,7 +58,7 @@ defmodule SpacesuitAuthMiddlewareTest do
       assert {:ok, ^req, ^env} = Spacesuit.AuthMiddleware.execute(req, env)
     end
 
-   test "with a missing token when session service is enabled" do
+    test "with a missing token when session service is enabled" do
       Application.put_env(:spacesuit, :session_service, %{ enabled: true, impl: Spacesuit.MockSessionService })
 
       req = %{ headers: %{ "authorization" => "Bearer " }, pid: self(), streamid: 1, method: "GET" }
@@ -66,6 +66,28 @@ defmodule SpacesuitAuthMiddlewareTest do
 
       # Unrecognized, we pass it on as is
       assert {:ok, ^req, ^env} = Spacesuit.AuthMiddleware.execute(req, env)
+    end
+
+    test "with a valid token on a bypassed path" do
+      Application.put_env(:spacesuit, :session_service, %{ enabled: true, impl: Spacesuit.MockSessionService })
+      Application.put_env(:handler_opts, :middlewares_config, %{ auth: %{ bypass_session_srv: true } })
+
+      req = %{ headers: %{ "authorization" => "Bearer ok" }, pid: self(), streamid: 1, method: "GET" }
+      env = %{}
+
+      # pass it on as is
+      assert {:ok, ^req, ^env} = Spacesuit.AuthMiddleware.execute(req, env)
+    end
+
+    test "with an invalid token on a bypassed path" do
+      Application.put_env(:spacesuit, :session_service, %{ enabled: true, impl: Spacesuit.MockSessionService })
+      Application.put_env(:handler_opts, :middlewares_config, %{ auth: %{ bypass_session_srv: true } })
+
+      req = %{ headers: %{ "authorization" => "Bearer error" }, pid: self(), streamid: 1, method: "GET" }
+      env = %{}
+
+      # Unrecognized, we pass it on as is
+      assert {:stop, ^req} = Spacesuit.AuthMiddleware.execute(req, env)
     end
   end
 end


### PR DESCRIPTION
When the session service is enabled, the auth middleware attempts to [validate](https://github.com/relistan/spacesuit/blob/master/lib/spacesuit/session_service.ex#L54) and [enrich](https://github.com/relistan/spacesuit/blob/master/lib/spacesuit/session_service.ex#L55) all requests containing a bearer token. However, there are some use cases where this enrichment should not occur and the access token should pass through to the backing service instead of the enriched session token. This patch provides for the definition of sigils that can be used to match incoming request paths against to determine whether or not the session service should be bypassed.