### PR TITLE
Fix routes for different HTTP verbs to work with different endpoints

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -19,7 +19,7 @@ config :spacesuit, routes: %{
     { "/users/:user_id", %{
       description: "users to [::1]:9090",
       GET: "http://[::1]:9090/:user_id", # ipv6 localhost (thanks osx)
-      POST: "http://[::1]:9090/:user_id",
+      POST: "http://[::1]:9000/:user_id",
       add_headers: %{
         "X-Something-Special" => "Some value"
       }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.4.1
+FROM elixir:1.4.2
 
 ADD . /spacesuit
 

--- a/lib/spacesuit.ex
+++ b/lib/spacesuit.ex
@@ -14,8 +14,6 @@ defmodule Spacesuit do
 
     dispatch = Spacesuit.Router.load_routes |> :cowboy_router.compile
 
-    Apex.ap dispatch
-
     {:ok, _} = :cowboy.start_clear(
         :http, 100, [port: @http_port],
         %{

--- a/lib/spacesuit.ex
+++ b/lib/spacesuit.ex
@@ -14,6 +14,8 @@ defmodule Spacesuit do
 
     dispatch = Spacesuit.Router.load_routes |> :cowboy_router.compile
 
+    Apex.ap dispatch
+
     {:ok, _} = :cowboy.start_clear(
         :http, 100, [port: @http_port],
         %{

--- a/lib/spacesuit/router.ex
+++ b/lib/spacesuit/router.ex
@@ -141,7 +141,7 @@ defmodule Spacesuit.Router do
   def compile(map) do
     uri = URI.parse(to_string(map))
 
-    if uri.path != nil do
+    compiled_map = if uri.path != nil do
       # Order of split strings is important so we end up
       # with output like "/part1/part2" vs "/part1//part2"
       String.split(uri.path, ["/[.", "[.", "/"])
@@ -149,5 +149,7 @@ defmodule Spacesuit.Router do
     else
       [] 
     end
+
+    [ uri, compiled_map ]
   end
 end

--- a/lib/spacesuit/router.ex
+++ b/lib/spacesuit/router.ex
@@ -35,9 +35,9 @@ defmodule Spacesuit.Router do
 
     compiled_opts =
       opts
-      |> add_all_actions
       |> process_verbs
       |> process_headers
+      |> add_all_actions
 
     {route, Spacesuit.ProxyHandler, compiled_opts}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Spacesuit.Mixfile do
     [app: :spacesuit,
      version: "0.1.0",
      elixir: "~> 1.4",
-     build_embedded: build_embedded?(),
+     #build_embedded: build_embedded?(),
      start_permanent: Mix.env == :prod,
      deps: deps(),
      test_coverage: [tool: ExCoveralls],
@@ -54,7 +54,8 @@ defmodule Spacesuit.Mixfile do
 
       # Test only
       {:excoveralls, "~> 0.6", only: :test},
-      {:mock, "~> 0.1.1", only: :test}
+      {:mock, "~> 0.1.1", only: :test},
+      {:apex, "~>1.1.0"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Spacesuit.Mixfile do
     [app: :spacesuit,
      version: "0.1.0",
      elixir: "~> 1.4",
-     #build_embedded: build_embedded?(),
+     build_embedded: build_embedded?(),
      start_permanent: Mix.env == :prod,
      deps: deps(),
      test_coverage: [tool: ExCoveralls],

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"afunix": {:git, "https://github.com/tonyrog/afunix.git", "37611258f5446a578391c23def6ca4565c4c67e7", [tag: "1.0"]},
   "amqp_client": {:git, "git://github.com/jbrisbin/amqp_client.git", "0878abe6b40cc202b35d86fae32698598c022f0d", [tag: "rabbitmq-3.3.5"]},
+  "apex": {:hex, :apex, "1.1.0", "d7a03b8d3e4d9241bd33d986f7bc440f32987ca92dfbec07d491f85593791c82", [:mix], []},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], []},
   "bear": {:hex, :bear, "0.8.3", "866002127a97932720a0d475d8582c98ec5fb78db3a18dfe7eaf91594d9024b8", [:rebar3], []},
   "certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},

--- a/test/mix_tasks_validate_routes_test.exs
+++ b/test/mix_tasks_validate_routes_test.exs
@@ -53,7 +53,7 @@ defmodule MixTasksValidateRoutesTest do
 
     test "invalid uri arg should throw" do
         assert_raise RuntimeError, fn ->
-            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", :handler, %{ uri: nil }})
+            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", :handler, %{ GET: nil }})
         end
     end
 end

--- a/test/spacesuit_proxy_handler_test.exs
+++ b/test/spacesuit_proxy_handler_test.exs
@@ -84,7 +84,9 @@ defmodule SpacesuitProxyHandlerTest do
   end
 
   test "building the upstream url when bindings exist" do
-    route_map = Spacesuit.Router.compile(:GET, "http://elsewhere.example.com/:asdf")
+    uri_str = "http://elsewhere.example.com/:asdf"
+
+    route_map = %{ GET: [ URI.parse(uri_str), Spacesuit.Router.compile(uri_str) ] }
 
     req = %{ bindings: [asdf: "foo"], method: "GET", qs: "", path_info: [] }
     url = Spacesuit.ProxyHandler.build_upstream_url(req, route_map)
@@ -93,7 +95,8 @@ defmodule SpacesuitProxyHandlerTest do
   end
 
   test "building the upstream url when there is a query string" do
-    route_map = Spacesuit.Router.compile(:GET, "http://elsewhere.example.com/:asdf")
+    uri_str = "http://elsewhere.example.com/:asdf"
+    route_map = %{ GET: [ URI.parse(uri_str), Spacesuit.Router.compile(uri_str) ] }
 
     req = %{
       bindings: [asdf: "foo"], method: "GET",

--- a/test/spacesuit_proxy_handler_test.exs
+++ b/test/spacesuit_proxy_handler_test.exs
@@ -86,7 +86,7 @@ defmodule SpacesuitProxyHandlerTest do
   test "building the upstream url when bindings exist" do
     uri_str = "http://elsewhere.example.com/:asdf"
 
-    route_map = %{ GET: [ URI.parse(uri_str), Spacesuit.Router.compile(uri_str) ] }
+    route_map = %{ GET: Spacesuit.Router.compile(uri_str) }
 
     req = %{ bindings: [asdf: "foo"], method: "GET", qs: "", path_info: [] }
     url = Spacesuit.ProxyHandler.build_upstream_url(req, route_map)
@@ -96,7 +96,7 @@ defmodule SpacesuitProxyHandlerTest do
 
   test "building the upstream url when there is a query string" do
     uri_str = "http://elsewhere.example.com/:asdf"
-    route_map = %{ GET: [ URI.parse(uri_str), Spacesuit.Router.compile(uri_str) ] }
+    route_map = %{ GET: Spacesuit.Router.compile(uri_str) }
 
     req = %{
       bindings: [asdf: "foo"], method: "GET",

--- a/test/spacesuit_router_test.exs
+++ b/test/spacesuit_router_test.exs
@@ -51,7 +51,7 @@ defmodule SpacesuitRouterTest do
 
   test "that build() can process the output from compile when only a path_map exists" do
     uri_str = "http://example.com/users/[...]"
-    route_map = Spacesuit.Router.compile(:GET, uri_str)
+    route_map = %{ GET: [ URI.parse(uri_str), Spacesuit.Router.compile(uri_str) ] }
 
     result = Spacesuit.Router.build("get", "", route_map, [], ["123"])
     assert result == "http://example.com/users/123"

--- a/test/spacesuit_router_test.exs
+++ b/test/spacesuit_router_test.exs
@@ -34,16 +34,19 @@ defmodule SpacesuitRouterTest do
     assert [] != Spacesuit.Router.transform_routes(state[:routes])
   end
 
-  test "that compiling routes returns a list of functions" do
+  test "that compiling routes returns a uri and list of functions" do
     uri_str = "http://example.com/users/:user_id"
 
-    route_map = Spacesuit.Router.compile(uri_str)
+    [ uri, route_map ] = Spacesuit.Router.compile(uri_str)
     assert Enum.all?(route_map, fn(x) -> is_function(x, 2) end)
+
+    parsed_uri = URI.parse(uri)
+    assert parsed_uri.host == "example.com"
   end
 
   test "that build() can process the output from compile" do
     uri_str = "http://example.com/users/:user_id[...]"
-    route_map = %{ GET: [ URI.parse(uri_str), Spacesuit.Router.compile(uri_str) ] }
+    route_map = %{ GET: Spacesuit.Router.compile(uri_str) }
 
     result = Spacesuit.Router.build("get", "", route_map, [user_id: 123], ["doc"])
     assert result == "http://example.com/users/123/doc"
@@ -51,7 +54,7 @@ defmodule SpacesuitRouterTest do
 
   test "that build() can process the output from compile when only a path_map exists" do
     uri_str = "http://example.com/users/[...]"
-    route_map = %{ GET: [ URI.parse(uri_str), Spacesuit.Router.compile(uri_str) ] }
+    route_map = %{ GET: Spacesuit.Router.compile(uri_str) }
 
     result = Spacesuit.Router.build("get", "", route_map, [], ["123"])
     assert result == "http://example.com/users/123"

--- a/test/spacesuit_router_test.exs
+++ b/test/spacesuit_router_test.exs
@@ -34,17 +34,16 @@ defmodule SpacesuitRouterTest do
     assert [] != Spacesuit.Router.transform_routes(state[:routes])
   end
 
-  test "that compiling routes returns the right structure" do
+  test "that compiling routes returns a list of functions" do
     uri_str = "http://example.com/users/:user_id"
 
-    %{ GET: route_map, uri: uri } = Spacesuit.Router.compile(:GET, uri_str)
+    route_map = Spacesuit.Router.compile(uri_str)
     assert Enum.all?(route_map, fn(x) -> is_function(x, 2) end)
-    assert URI.to_string(uri) == uri_str
   end
 
   test "that build() can process the output from compile" do
     uri_str = "http://example.com/users/:user_id[...]"
-    route_map = Spacesuit.Router.compile(:GET, uri_str)
+    route_map = %{ GET: [ URI.parse(uri_str), Spacesuit.Router.compile(uri_str) ] }
 
     result = Spacesuit.Router.build("get", "", route_map, [user_id: 123], ["doc"])
     assert result == "http://example.com/users/123/doc"


### PR DESCRIPTION
This fixes a bug where the different HTTP verbs were all sharing a single routing URI (the last specified) regardless of whether or not they were pointed at different targets.