### PR TITLE
Turn down logging

### DIFF
--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -9,7 +9,7 @@ defmodule Spacesuit.ProxyHandler do
   @timed key: "timed.proxyHandler-handle", units: :millisecond
   def init(req, state) do
     route_name = Map.get(state, :description, "un-named")
-    Logger.info("Processing '#{route_name}'")
+    Logger.debug("Processing '#{route_name}'")
 
     %{method: method, headers: headers, peer: peer} = req
 

--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -107,7 +107,7 @@ defmodule Spacesuit.ProxyHandler do
   def hackney_to_cowboy(headers) do
     headers
     |> List.foldl(%{}, fn {k, v}, memo -> Map.put(memo, String.downcase(k), v) end)
-    |> Map.drop(["Date", "date", "Content-Length", "content-length"])
+    |> Map.drop(["date", "content-length"])
   end
 
   # Format the peer from the request into a string that

--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -107,7 +107,7 @@ defmodule Spacesuit.ProxyHandler do
   def hackney_to_cowboy(headers) do
     headers
     |> List.foldl(%{}, fn {k, v}, memo -> Map.put(memo, String.downcase(k), v) end)
-    |> Map.drop(["Date", "date"])
+    |> Map.drop(["Date", "date", "Content-Length", "content-length"])
   end
 
   # Format the peer from the request into a string that

--- a/test/spacesuit_proxy_handler_test.exs
+++ b/test/spacesuit_proxy_handler_test.exs
@@ -32,6 +32,17 @@ defmodule SpacesuitProxyHandlerTest do
       processed = Spacesuit.ProxyHandler.hackney_to_cowboy(headers)
       assert Enum.all?(Map.keys(processed), fn k -> k == String.downcase(k) end)
     end
+
+    test "drops the content-length since we're running chunked encoding" do
+      headers = [
+        {"Content-Length", "1500"},
+        {"content-length", "1500"},
+        {"Another-Header", "this is valid"}
+      ]
+
+      processed = Spacesuit.ProxyHandler.hackney_to_cowboy(headers)
+      assert Enum.count(processed) == 1
+    end
   end
 
   test "adding headers specified in the config" do


### PR DESCRIPTION
This should vastly reduce the logging that Spacesuit does by default. Now it will really only report warnings errors, and important information rather than reporting every request.