### PR TITLE
Turn down logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ You need to have Elixir and the BEAM VM installed. On OSX the easiest way to do
 that is to `brew install elixir`. Next you need to install dependencies, with
 `mix deps.get`. Now you're ready to roll.
 
+*Note*: To run `mix compile` or `mix test` you also have to install Rebar3, the Erlang build system.
+On OSX, use `brew install rebar` to install it.
+
 Running
 -------
 

--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -9,7 +9,7 @@ defmodule Spacesuit.ProxyHandler do
   @timed key: "timed.proxyHandler-handle", units: :millisecond
   def init(req, state) do
     route_name = Map.get(state, :description, "un-named")
-    Logger.info("Processing '#{route_name}'")
+    Logger.debug("Processing '#{route_name}'")
 
     %{method: method, headers: headers, peer: peer} = req
 

--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -107,7 +107,7 @@ defmodule Spacesuit.ProxyHandler do
   def hackney_to_cowboy(headers) do
     headers
     |> List.foldl(%{}, fn {k, v}, memo -> Map.put(memo, String.downcase(k), v) end)
-    |> Map.drop(["Date", "date", "Content-Length", "content-length"])
+    |> Map.drop(["date", "content-length"])
   end
 
   # Format the peer from the request into a string that

--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -107,7 +107,7 @@ defmodule Spacesuit.ProxyHandler do
   def hackney_to_cowboy(headers) do
     headers
     |> List.foldl(%{}, fn {k, v}, memo -> Map.put(memo, String.downcase(k), v) end)
-    |> Map.drop(["Date", "date"])
+    |> Map.drop(["Date", "date", "Content-Length", "content-length"])
   end
 
   # Format the peer from the request into a string that

--- a/lib/spacesuit/router.ex
+++ b/lib/spacesuit/router.ex
@@ -40,7 +40,10 @@ defmodule Spacesuit.Router do
       |> process_headers
       |> add_all_actions
 
-    {route, Spacesuit.ProxyHandler, compiled_opts}
+    constraints = Map.get(compiled_opts, :constraints, [])
+    compiled_opts = Map.delete(compiled_opts, :constraints)
+
+    {route, constraints, Spacesuit.ProxyHandler, compiled_opts}
   end
 
   # Expose the verbs to the outside

--- a/test/mix_tasks_validate_routes_test.exs
+++ b/test/mix_tasks_validate_routes_test.exs
@@ -3,7 +3,8 @@ defmodule MixTasksValidateRoutesTest do
     doctest Mix.Tasks.ValidateRoutes
 
     test "valid routes should be ok" do
-        route = {"/path", :handler,
+        constraint = {:pathvariable, fn(_) -> true end}
+        route = {"/path", [constraint], :handler,
             %{
                 description: "dummy route",
                 uri: URI.parse("http://example.com/"),
@@ -23,37 +24,50 @@ defmodule MixTasksValidateRoutesTest do
 
     test "should throw if handler is not an atom" do
         assert_raise RuntimeError, fn ->
-            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", "not an atom", %{}})
+            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", [], "not an atom", %{}})
         end
     end
 
     test "should throw if args is not a map" do
         assert_raise RuntimeError, fn ->
-            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", :handler, :not_a_map})
+            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", [], :handler, :not_a_map})
         end
     end
 
     test "invalid path should throw" do
         assert_raise RuntimeError, fn ->
-            Mix.Tasks.ValidateRoutes.validate_one_route({:not_a_path, :handler, %{}})
+            Mix.Tasks.ValidateRoutes.validate_one_route({:not_a_path, [], :handler, %{}})
         end
     end
 
     test "add_headers should throw if it is not a map" do
         assert_raise RuntimeError, fn ->
-            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", :handler, %{ add_headers: "not a map" }})
+            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", [], :handler, %{ add_headers: "not a map" }})
         end
     end
 
     test "invalid arg map key should throw" do
         assert_raise RuntimeError, fn ->
-            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", :handler, %{ bad_option: "oops" }})
+            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", [], :handler, %{ bad_option: "oops" }})
         end
     end
 
     test "invalid uri arg should throw" do
         assert_raise RuntimeError, fn ->
-            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", :handler, %{ GET: nil }})
+            Mix.Tasks.ValidateRoutes.validate_one_route({"/path", [], :handler, %{ GET: nil }})
         end
+    end
+
+
+    test "invalid constraint path variable should throw" do
+      assert_raise RuntimeError, fn ->
+        Mix.Tasks.ValidateRoutes.validate_one_route({"/path", [{"not an atom", fn(_) -> true end}], :handler, %{}})
+      end
+    end
+
+    test "invalid constraint function should throw" do
+      assert_raise RuntimeError, fn ->
+        Mix.Tasks.ValidateRoutes.validate_one_route({"/path", [{:pathvariable, "not a function"}], :handler, %{}})
+      end
     end
 end

--- a/test/spacesuit_proxy_handler_test.exs
+++ b/test/spacesuit_proxy_handler_test.exs
@@ -32,6 +32,17 @@ defmodule SpacesuitProxyHandlerTest do
       processed = Spacesuit.ProxyHandler.hackney_to_cowboy(headers)
       assert Enum.all?(Map.keys(processed), fn k -> k == String.downcase(k) end)
     end
+
+    test "drops the content-length since we're running chunked encoding" do
+      headers = [
+        {"Content-Length", "1500"},
+        {"content-length", "1500"},
+        {"Another-Header", "this is valid"}
+      ]
+
+      processed = Spacesuit.ProxyHandler.hackney_to_cowboy(headers)
+      assert Enum.count(processed) == 1
+    end
   end
 
   test "adding headers specified in the config" do

--- a/test/spacesuit_router_test.exs
+++ b/test/spacesuit_router_test.exs
@@ -81,7 +81,7 @@ defmodule SpacesuitRouterTest do
     } = state[:routes]
 
     output = Spacesuit.Router.transform_one_route(route)
-    {_route, _handler, handler_opts} = output
+    {_route, [], _handler, handler_opts} = output
 
     assert [_one, _two] = Map.get(handler_opts, :GET)
   end
@@ -95,10 +95,26 @@ defmodule SpacesuitRouterTest do
        }}
 
     output = Spacesuit.Router.transform_one_route(route)
-    {_route, _handler, handler_opts} = output
+    {_route, [], _handler, handler_opts} = output
 
     assert [_one, _two] = Map.get(handler_opts, :GET)
     assert [_one, _two] = Map.get(handler_opts, :OPTIONS)
+  end
+
+  test "transforming one route with :constraints" do
+    route =
+      {'/users/:user_id',
+        %{
+          description: 'users to localhost',
+          GET: 'http://localhost:9090/:user_id',
+          constraints: [{:user_id, :int}]
+        }}
+
+    output = Spacesuit.Router.transform_one_route(route)
+    {_route, constraint, _handler, handler_opts} = output
+
+    assert [_one, _two] = Map.get(handler_opts, :GET)
+    assert [{:user_id, :int}] = constraint
   end
 
   test "adds health route when configured to", state do
@@ -112,7 +128,7 @@ defmodule SpacesuitRouterTest do
     Application.put_env(:spacesuit, :health_route, %{enabled: false, path: "/health"})
     [first_route | _] = Spacesuit.Router.transform_routes(state[:routes])
 
-    {':_', [{route_path, handler, _map} | _]} = first_route
+    {':_', [{route_path, [], handler, _map} | _]} = first_route
     assert "/health" != route_path
     assert Spacesuit.HealthHandler != handler
   end
@@ -129,7 +145,7 @@ defmodule SpacesuitRouterTest do
     } = state[:routes]
 
     output = Spacesuit.Router.transform_one_route(route)
-    {_route, _handler, handler_opts} = output
+    {_route, [], _handler, handler_opts} = output
 
     assert map_size(handler_opts[:add_headers]) == 2
     assert handler_opts[:add_headers]["X-Something-Invalid"] == "123"


### PR DESCRIPTION
This should turn off 95% of the logging for Spacesuit by ending the logging for each request like it does now. Remaining logs will be for warnings, errors, or other important messages.